### PR TITLE
Export cleaned up Stats type

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -189,9 +189,7 @@ func parseMessage(m genetlink.Message) (*Stats, error) {
 				return nil, fmt.Errorf("unexpected taskstats structure size, want %d, got %d", want, got)
 			}
 
-			// TODO(mdlayher): parse raw unix.Taskstats structure into nicer structure.
-			stats := Stats(*(*unix.Taskstats)(unsafe.Pointer(&na.Data[0])))
-			return &stats, nil
+			return parseStats(*(*unix.Taskstats)(unsafe.Pointer(&na.Data[0])))
 		}
 	}
 

--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -6,9 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/taskstats"
-	"golang.org/x/sys/unix"
 )
 
 func TestLinuxClientIntegration(t *testing.T) {
@@ -37,12 +35,8 @@ func testSelfStats(t *testing.T, c *taskstats.Client) {
 		t.Fatalf("failed to retrieve self stats: %v", err)
 	}
 
-	if diff := cmp.Diff(unix.TASKSTATS_VERSION, int(stats.Version)); diff != "" {
-		t.Fatalf("unexpected taskstats version (-want +got):\n%s", diff)
-	}
-
-	if diff := cmp.Diff(os.Getpid(), int(stats.Ac_pid)); diff != "" {
-		t.Fatalf("unexpected PID (-want +got):\n%s", diff)
+	if stats.BeginTime.IsZero() {
+		t.Fatalf("unexpected zero begin time")
 	}
 
 	// TODO(mdlayher): verify more fields?

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 	"unsafe"
 
 	"github.com/google/go-cmp/cmp"
@@ -263,8 +264,22 @@ func TestLinuxClientPIDOK(t *testing.T) {
 	pid := os.Getpid()
 
 	stats := unix.Taskstats{
-		Version: unix.TASKSTATS_VERSION,
-		Ac_pid:  uint32(pid),
+		Version:               unix.TASKSTATS_VERSION,
+		Ac_pid:                uint32(pid),
+		Ac_etime:              0,
+		Ac_utime:              1,
+		Ac_stime:              2,
+		Ac_btime:              3,
+		Ac_minflt:             4,
+		Ac_majflt:             5,
+		Cpu_count:             6,
+		Cpu_delay_total:       7,
+		Blkio_count:           8,
+		Blkio_delay_total:     9,
+		Swapin_count:          10,
+		Swapin_delay_total:    11,
+		Freepages_count:       12,
+		Freepages_delay_total: 13,
 	}
 
 	fn := func(_ genetlink.Message, _ netlink.Message) ([]genetlink.Message, error) {
@@ -290,7 +305,22 @@ func TestLinuxClientPIDOK(t *testing.T) {
 		t.Fatalf("failed to get stats: %v", err)
 	}
 
-	tstats := Stats(stats)
+	tstats := Stats{
+		ElapsedTime:         time.Duration(0),
+		UserCPUTime:         time.Microsecond * 1,
+		SystemCPUTime:       time.Microsecond * 2,
+		BeginTime:           time.Unix(3, 0),
+		MinorPageFaults:     4,
+		MajorPageFaults:     5,
+		CPUDelayCount:       6,
+		CPUDelay:            time.Nanosecond * 7,
+		BlockIODelayCount:   8,
+		BlockIODelay:        time.Nanosecond * 9,
+		SwapInDelayCount:    10,
+		SwapInDelay:         time.Nanosecond * 11,
+		FreePagesDelayCount: 12,
+		FreePagesDelay:      time.Nanosecond * 13,
+	}
 
 	if diff := cmp.Diff(&tstats, newStats); diff != "" {
 		t.Fatalf("unexpected taskstats structure (-want +got):\n%s", diff)

--- a/client_others.go
+++ b/client_others.go
@@ -14,9 +14,6 @@ var (
 		runtime.GOOS, runtime.GOARCH)
 )
 
-// Stats is not implemented on this platform.
-type Stats struct{}
-
 var _ osClient = &client{}
 
 // A client is an unimplemented taskstats client.

--- a/stats.go
+++ b/stats.go
@@ -11,15 +11,20 @@ type CGroupStats struct {
 	IOWait          uint64
 }
 
-// TODO(mdlayher): export cleaned up Stats type.
-type stats struct {
-	BeginTime       time.Time
-	ElapsedTime     time.Duration
-	UserCPUTime     time.Duration
-	SystemCPUTime   time.Duration
-	MinorPageFaults uint64
-	MajorPageFaults uint64
-
-	CPUCount uint64
-	CPUDelay time.Duration
+// Stats contains statistics for an individual task.
+type Stats struct {
+	BeginTime           time.Time
+	ElapsedTime         time.Duration
+	UserCPUTime         time.Duration
+	SystemCPUTime       time.Duration
+	MinorPageFaults     uint64
+	MajorPageFaults     uint64
+	CPUDelayCount       uint64
+	CPUDelay            time.Duration
+	BlockIODelayCount   uint64
+	BlockIODelay        time.Duration
+	SwapInDelayCount    uint64
+	SwapInDelay         time.Duration
+	FreePagesDelayCount uint64
+	FreePagesDelay      time.Duration
 }

--- a/stats_linux.go
+++ b/stats_linux.go
@@ -6,11 +6,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// TODO(mdlayher+andrestc): remove this Stats type when stats is exported.
-
-// Stats is the structure returned by Linux's taskstats interface.
-type Stats unix.Taskstats
-
 // parseCGroupStats parses a raw cgroupstats structure into a cleaner form.
 func parseCGroupStats(cs unix.CGroupStats) (*CGroupStats, error) {
 	// This conversion isn't really necessary for this type, but it allows us
@@ -27,17 +22,22 @@ func parseCGroupStats(cs unix.CGroupStats) (*CGroupStats, error) {
 }
 
 // parseStats parses a raw taskstats structure into a cleaner form.
-func parseStats(ts unix.Taskstats) (*stats, error) {
-	stats := &stats{
-		BeginTime:       time.Unix(int64(ts.Ac_btime), 0),
-		ElapsedTime:     microseconds(ts.Ac_etime),
-		UserCPUTime:     microseconds(ts.Ac_utime),
-		SystemCPUTime:   microseconds(ts.Ac_stime),
-		MinorPageFaults: ts.Ac_minflt,
-		MajorPageFaults: ts.Ac_majflt,
-
-		CPUCount: ts.Cpu_count,
-		CPUDelay: nanoseconds(ts.Cpu_delay_total),
+func parseStats(ts unix.Taskstats) (*Stats, error) {
+	stats := &Stats{
+		BeginTime:           time.Unix(int64(ts.Ac_btime), 0),
+		ElapsedTime:         microseconds(ts.Ac_etime),
+		UserCPUTime:         microseconds(ts.Ac_utime),
+		SystemCPUTime:       microseconds(ts.Ac_stime),
+		MinorPageFaults:     ts.Ac_minflt,
+		MajorPageFaults:     ts.Ac_majflt,
+		CPUDelayCount:       ts.Cpu_count,
+		CPUDelay:            nanoseconds(ts.Cpu_delay_total),
+		BlockIODelayCount:   ts.Blkio_count,
+		BlockIODelay:        nanoseconds(ts.Blkio_delay_total),
+		SwapInDelayCount:    ts.Swapin_count,
+		SwapInDelay:         nanoseconds(ts.Swapin_delay_total),
+		FreePagesDelayCount: ts.Freepages_count,
+		FreePagesDelay:      nanoseconds(ts.Freepages_delay_total),
 	}
 
 	return stats, nil


### PR DESCRIPTION
This PR exports the Stats struct and adds delay accounting fields
to it.

I've renamed CPUCount to CPUDelayCount to avoid mistaking this value with
the number of CPUs. Other counts follow the same pattern.

Thought about having a DelayStats struct but might be an overkill.

Related to #1.