### PR TITLE
Fix statistics by collecting thread group info

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -61,7 +61,7 @@ func (c *client) Close() error {
 func (c *client) PID(pid int) (*Stats, error) {
 	// Query taskstats for information using a specific PID.
 	attrb, err := netlink.MarshalAttributes([]netlink.Attribute{{
-		Type: unix.TASKSTATS_CMD_ATTR_PID,
+		Type: unix.TASKSTATS_CMD_ATTR_TGID,
 		Data: nlenc.Uint32Bytes(uint32(pid)),
 	}})
 	if err != nil {
@@ -167,7 +167,7 @@ func parseMessage(m genetlink.Message) (*Stats, error) {
 
 	for _, a := range attrs {
 		// Only parse PID+stats structure.
-		if a.Type != unix.TASKSTATS_TYPE_AGGR_PID {
+		if a.Type != unix.TASKSTATS_TYPE_AGGR_TGID {
 			continue
 		}
 

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -88,7 +88,7 @@ func TestLinuxClientCGroupStatsIsNotExist(t *testing.T) {
 			msg: genetlink.Message{
 				Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
 					// Wrong type for cgroup stats.
-					Type: unix.TASKSTATS_TYPE_AGGR_PID,
+					Type: unix.TASKSTATS_TYPE_AGGR_TGID,
 				}}),
 			},
 			createFile: true,
@@ -196,7 +196,7 @@ func TestLinuxClientPIDBadMessages(t *testing.T) {
 			name: "incorrect taskstats size",
 			msgs: []genetlink.Message{{
 				Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
-					Type: unix.TASKSTATS_TYPE_AGGR_PID,
+					Type: unix.TASKSTATS_TYPE_AGGR_TGID,
 					Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
 						Type: unix.TASKSTATS_TYPE_STATS,
 						Data: []byte{0xff},
@@ -242,7 +242,7 @@ func TestLinuxClientPIDIsNotExist(t *testing.T) {
 			name: "no stats",
 			msg: genetlink.Message{
 				Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
-					Type: unix.TASKSTATS_TYPE_AGGR_PID,
+					Type: unix.TASKSTATS_TYPE_AGGR_TGID,
 					Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
 						Type: unix.TASKSTATS_TYPE_NULL,
 					}}),
@@ -294,7 +294,7 @@ func TestLinuxClientPIDOK(t *testing.T) {
 
 		return []genetlink.Message{{
 			Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
-				Type: unix.TASKSTATS_TYPE_AGGR_PID,
+				Type: unix.TASKSTATS_TYPE_AGGR_TGID,
 				Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
 					Type: unix.TASKSTATS_TYPE_STATS,
 					Data: b[:],


### PR DESCRIPTION
Since Go uses threads internally, collecting information solely about
the requested PID will provide incomplete taskstats data.  We need
to ask the kernel for thread group statistics instead.