### PR TITLE
Add TGID method

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,19 @@ For more information on taskstats, please see:
   - https://www.kernel.org/doc/Documentation/accounting/taskstats-struct.txt
   - https://andrestc.com/post/linux-delay-accounting/
 
+Notes
+-----
+* When instrumenting Go programs, use either the `taskstats.Self()` or
+  `taskstats.TGID()` method.  Using the `PID()` method on multithreaded
+  programs, including Go programs, will produce inaccurate results.
+
+* Access to taskstats requires that the application have at least `CAP_NET_RAW`
+  capability (see
+  [capabilities(7)](http://man7.org/linux/man-pages/man7/capabilities.7.html)).
+  Otherwise, the application must be run as root.
+
+* If running the application in a container (e.g. via Docker), it cannot be run
+  in a network namespace -- usually this means that host networking must be
+  used.
+
 MIT Licensed.

--- a/client.go
+++ b/client.go
@@ -44,12 +44,17 @@ func (c *Client) CGroupStats(path string) (*CGroupStats, error) {
 // Self is a convenience method for retrieving statistics about the current
 // process.
 func (c *Client) Self() (*Stats, error) {
-	return c.c.PID(os.Getpid())
+	return c.c.TGID(os.Getpid())
 }
 
 // PID retrieves statistics about a process, identified by its PID.
 func (c *Client) PID(pid int) (*Stats, error) {
 	return c.c.PID(pid)
+}
+
+// TGID retrieves statistics about a thread group, identified by its TGID.
+func (c *Client) TGID(tgid int) (*Stats, error) {
+	return c.c.TGID(tgid)
 }
 
 // Close releases resources used by a Client.
@@ -62,4 +67,5 @@ type osClient interface {
 	io.Closer
 	CGroupStats(path string) (*CGroupStats, error)
 	PID(pid int) (*Stats, error)
+	TGID(tgid int) (*Stats, error)
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -59,10 +59,19 @@ func (c *client) Close() error {
 
 // PID implements osClient.
 func (c *client) PID(pid int) (*Stats, error) {
-	// Query taskstats for information using a specific PID.
+	return c.getStats(pid, unix.TASKSTATS_CMD_ATTR_PID, unix.TASKSTATS_TYPE_AGGR_PID)
+}
+
+// TGID implements osClient.
+func (c *client) TGID(tgid int) (*Stats, error) {
+	return c.getStats(tgid, unix.TASKSTATS_CMD_ATTR_TGID, unix.TASKSTATS_TYPE_AGGR_TGID)
+}
+
+func (c *client) getStats(id int, cmdAttr, typeAggr uint16) (*Stats, error) {
+	// Query taskstats for information using a specific ID.
 	attrb, err := netlink.MarshalAttributes([]netlink.Attribute{{
-		Type: unix.TASKSTATS_CMD_ATTR_PID,
-		Data: nlenc.Uint32Bytes(uint32(pid)),
+		Type: cmdAttr,
+		Data: nlenc.Uint32Bytes(uint32(id)),
 	}})
 	if err != nil {
 		return nil, err
@@ -87,7 +96,7 @@ func (c *client) PID(pid int) (*Stats, error) {
 		return nil, fmt.Errorf("unexpected number of taskstats messages: %d", l)
 	}
 
-	return parseMessage(msgs[0])
+	return parseMessage(msgs[0], typeAggr)
 }
 
 // CGroupStats implements osClient.
@@ -159,15 +168,15 @@ func parseCGroupMessage(m genetlink.Message) (*CGroupStats, error) {
 }
 
 // parseMessage attempts to parse a Stats structure from a generic netlink message.
-func parseMessage(m genetlink.Message) (*Stats, error) {
+func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 	attrs, err := netlink.UnmarshalAttributes(m.Data)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, a := range attrs {
-		// Only parse PID+stats structure.
-		if a.Type != unix.TASKSTATS_TYPE_AGGR_PID {
+		// Only parse ID+stats structure.
+		if a.Type != typeAggr {
 			continue
 		}
 
@@ -177,7 +186,7 @@ func parseMessage(m genetlink.Message) (*Stats, error) {
 		}
 
 		for _, na := range nattrs {
-			// Only parse Stats element since caller would already have PID.
+			// Only parse Stats element since caller would already have ID.
 			if na.Type != unix.TASKSTATS_TYPE_STATS {
 				continue
 			}


### PR DESCRIPTION
`taskstats.PID()` does not produce correct results on multi-threaded
programs, including Go programs.  Instead, one must request task
statistics relating to the thread group.  Here we provide a new
`TGID()` method for requesting those metrics, and update the
`taskstats.Self()` method to use it.

Also added some notes to the README that detail the runtime requirements
for collecting these statistics.