### PR TITLE
taskstats: fix sizeof unix.Taskstats after x/sys/unix update to Linux 4.20

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	// sizeofTaskstats is the size of a unix.Taskstats structure.
-	sizeofTaskstats   = int(unsafe.Sizeof(unix.Taskstats{}))
+	// sizeofTaskstatsV8 is the size of a unix.Taskstats structure as of
+	// taskstats version 8.
+	sizeofTaskstatsV8 = int(unsafe.Offsetof(unix.Taskstats{}.Thrashing_count))
 	sizeofCGroupStats = int(unsafe.Sizeof(unix.CGroupStats{}))
 )
 
@@ -194,7 +195,7 @@ func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 			// Verify that the byte slice containing a unix.Taskstats is the
 			// size expected by this package, so we don't blindly cast the
 			// byte slice into a structure of the wrong size.
-			if want, got := sizeofTaskstats, len(na.Data); want != got {
+			if want, got := sizeofTaskstatsV8, len(na.Data); want != got {
 				return nil, fmt.Errorf("unexpected taskstats structure size, want %d, got %d", want, got)
 			}
 

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -377,7 +377,7 @@ func TestLinuxClientPIDOK(t *testing.T) {
 
 	fn := func(_ genetlink.Message, _ netlink.Message) ([]genetlink.Message, error) {
 		// Cast unix.Taskstats structure into a byte array with the correct size.
-		b := *(*[sizeofTaskstats]byte)(unsafe.Pointer(&stats))
+		b := *(*[sizeofTaskstatsV8]byte)(unsafe.Pointer(&stats))
 
 		return []genetlink.Message{{
 			Data: nltest.MustMarshalAttributes([]netlink.Attribute{{
@@ -453,7 +453,7 @@ func TestLinuxClientTGIDOK(t *testing.T) {
 
 	fn := func(_ genetlink.Message, _ netlink.Message) ([]genetlink.Message, error) {
 		// Cast unix.Taskstats structure into a byte array with the correct size.
-		b := *(*[sizeofTaskstats]byte)(unsafe.Pointer(&stats))
+		b := *(*[sizeofTaskstatsV8]byte)(unsafe.Pointer(&stats))
 
 		return []genetlink.Message{{
 			Data: nltest.MustMarshalAttributes([]netlink.Attribute{{


### PR DESCRIPTION
With Linux kernel 4.20 two new members were added to struct taskstats
which increases its size (see torvalds/linux@b1d29ba).
Correspondingly, TASKSTATS_VERSION was bumped from 8 to 9. Thus, after
merging the Linux 4.20 changes to golang.org/x/sys/unix in
golang/sys@82a175f, the size check in func parseMessage fails due
to the size mismatch.

Adjust sizeofTaskstats for now to still reflect the size of the v8
struct. The new v9 members are not accessed in parseStats, so this
should be safe. A real fix (future) would probably be to parse the
taskstats version first and then check the size of the netlink data
depending on the version and only parse the corresponding fields in
parseStats.