### PR TITLE
fixed build on non-Linux OS: client.TGID stub method added

### DIFF
--- a/client_others.go
+++ b/client_others.go
@@ -38,3 +38,8 @@ func (c *client) CGroupStats(path string) (*CGroupStats, error) {
 func (c *client) PID(pid int) (*Stats, error) {
 	return nil, errUnimplemented
 }
+
+// TGID implements osClient.
+func (c *client) TGID(tgid int) (*Stats, error) {
+	return nil, errUnimplemented
+}


### PR DESCRIPTION
This PR fixes build error on darwin (and other non-Linux OS):
```
../../go/src/github.com/def/taskstats/client.go:31:3: cannot use c (type *client) as type osClient in field value:
	*client does not implement osClient (missing TGID method)
../../go/src/github.com/def/taskstats/client_others.go:17:5: cannot use client literal (type *client) as type osClient in assignment:
	*client does not implement osClient (missing TGID method)
```