### PR TITLE
added support for v11, v12, v13 of the `taskstats` struct

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -19,9 +19,10 @@ const (
 	sizeofV8 = int(unsafe.Offsetof(unix.Taskstats{}.Thrashing_count))
 	sizeofV9 = int(unsafe.Offsetof(unix.Taskstats{}.Ac_btime64))
 	// Current version.
-	sizeofV10 = int(unsafe.Sizeof(unix.Taskstats{}))
-
-	// TODO(mdlayher): sizeofV11 for Linux 5.17.
+	sizeofV10 = int(unsafe.Offsetof(unix.Taskstats{}.Ac_btime64) + unsafe.Sizeof(unix.Taskstats{}.Ac_btime64))
+	sizeofV11 = int(unsafe.Offsetof(unix.Taskstats{}.Compact_delay_total) + unsafe.Sizeof(unix.Taskstats{}.Compact_delay_total))
+	sizeofV12 = int(unsafe.Offsetof(unix.Taskstats{}.Ac_exe_inode) + unsafe.Sizeof(unix.Taskstats{}.Ac_exe_inode))
+	sizeofV13 = int(unsafe.Offsetof(unix.Taskstats{}.Wpcopy_delay_total) + unsafe.Sizeof(unix.Taskstats{}.Wpcopy_delay_total))
 
 	sizeofCGroupStats = int(unsafe.Sizeof(unix.CGroupStats{}))
 )
@@ -206,10 +207,10 @@ func parseMessage(m genetlink.Message, typeAggr uint16) (*Stats, error) {
 			// size expected by this package, so we don't blindly cast the
 			// byte slice into a structure of the wrong size.
 			switch l := len(na.Data); l {
-			case sizeofV8, sizeofV9, sizeofV10:
+			case sizeofV8, sizeofV9, sizeofV10, sizeofV11, sizeofV12, sizeofV13:
 				// OK, supported.
 			default:
-				return nil, fmt.Errorf("unexpected taskstats structure size: %d: does not match taskstats v8, v9, v10", l)
+				return nil, fmt.Errorf("unexpected taskstats structure size: %d: does not match taskstats v8, v9, v10, v11, v12, v13", l)
 			}
 
 			return parseStats(*(*unix.Taskstats)(unsafe.Pointer(&na.Data[0])))

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/mdlayher/genetlink v1.2.0
 	github.com/mdlayher/netlink v1.6.0
-	golang.org/x/sys v0.0.0-20220405210540-1e041c57c461
+	golang.org/x/sys v0.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220405210540-1e041c57c461 h1:kHVeDEnfKn3T238CvrUcz6KeEsFHVaKh4kMTt6Wsysg=
-golang.org/x/sys v0.0.0-20220405210540-1e041c57c461/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
+golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/stats.go
+++ b/stats.go
@@ -27,4 +27,6 @@ type Stats struct {
 	SwapInDelay         time.Duration
 	FreePagesDelayCount uint64
 	FreePagesDelay      time.Duration
+	ThrashingDelayCount uint64
+	ThrashingDelay      time.Duration
 }

--- a/stats_linux.go
+++ b/stats_linux.go
@@ -38,6 +38,8 @@ func parseStats(ts unix.Taskstats) (*Stats, error) {
 		SwapInDelay:         nanoseconds(ts.Swapin_delay_total),
 		FreePagesDelayCount: ts.Freepages_count,
 		FreePagesDelay:      nanoseconds(ts.Freepages_delay_total),
+		ThrashingDelayCount: ts.Thrashing_count,
+		ThrashingDelay:      nanoseconds(ts.Thrashing_delay_total),
 	}
 
 	return stats, nil


### PR DESCRIPTION
This PR adds support for all current versions of the [taskstats](https://elixir.bootlin.com/linux/v6.2.2/source/include/uapi/linux/taskstats.h#L41) structure. 
